### PR TITLE
Correct typos and wording in Introduction

### DIFF
--- a/proposals/NNNN-method-keypaths.md
+++ b/proposals/NNNN-method-keypaths.md
@@ -15,18 +15,18 @@ expressly limited key paths to be able to reference only properties and subscrip
 \Person.pets[0]               // KeyPath<Person, Pet>
 ```
 
-This proposal adds the ability for key paths to reference methods, optionally specifying argument names:
+This proposal adds the ability for key paths to reference instance methods, optionally specifying argument names to disambiguate:
 
 ```swift
 \Person.sing                  // KeyPath<Person, () -> Sound>
-\Person.sing(melody:lyrics:)  // KeyPath<Person, (Melody,String) -> Sound>
+\Person.sing(melody:lyrics:)  // KeyPath<Person, (Melody, String) -> Sound>
 ```
 
-Note that these key paths do not provide argument values; they reference _unapplied_ methods, and the value they give is
-a closure and not the result of calling the method.
+Note that these key paths do not provide argument values: they reference _unapplied_ methods, and the value they give is
+a function type rather than the return value thereof.
 
-Adding this capability not only removes a distateful inconsistency in Swift, but solves pratical problems involving
-map/filter operations, proxying with dynamic member lookup, and weak method references.
+Adding this capability both increases consistency and removes obstacles encountered when implementing
+map/filter operations, proxying with key path member lookup, binding weak method references, and performing other common tasks.
 
 Swift-evolution thread: [Why can’t key paths refer to instance methods?](https://forums.swift.org/t/why-can-t-key-paths-refer-to-instance-methods/35315)
 


### PR DESCRIPTION
At the moment, specifying arguments for methods is optional unless the compiler needs them to disambiguate.
This is specifically for instance methods: static properties in general are beyond the scope of this proposal, for the moment at least.
Despite sharing an attribute, dynamic member lookup and key path member lookup are not the same thing: “dynamic” means using a String-based subscript, which is obviously not relevant here.
It is important to remember that closures are already supported by key paths: this is specifically about instance methods, and the two are not interchangeable.
Try to avoid words like “distasteful”: these decisions were made for good reasons, and in this case it was simply a matter of narrowing scope.